### PR TITLE
Skip users that haven't submitted their calendar

### DIFF
--- a/src/main/java/com/google/sps/servlets/MatchingDateAlgo.java
+++ b/src/main/java/com/google/sps/servlets/MatchingDateAlgo.java
@@ -1,6 +1,4 @@
-
 package com.google.sps.servlets;
-
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -15,19 +13,20 @@ import static com.google.sps.Constants.*;
 import java.io.IOException;
 import java.util.List;
 import java.util.HashSet;
+import java.util.stream.Collectors;
 
 @WebServlet("/MatchingAlgoDate")
 public class MatchingDateAlgo extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         //Used to keep track of the good dates. HashSet used for constant "contains" time.
-        HashSet<LongValue> GoodDates = new HashSet<LongValue>();
+        HashSet<LongValue> goodDates = new HashSet<>();
 
         //Used to hold dates for each user from datastore
         List<LongValue> userDays;
 
-        //Used to *temporarily* hold the values which overlap in current GoodDates and userDays
-        HashSet<LongValue> temps = new HashSet<LongValue>();
+        //Used to *temporarily* hold the values which overlap in current goodDates and userDays
+        HashSet<LongValue> temps = new HashSet<>();
 
         //get objects in datastore
         Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
@@ -36,25 +35,28 @@ public class MatchingDateAlgo extends HttpServlet {
         QueryResults<Entity> results = datastore.run(query);
         while (results.hasNext()) {
             Entity entity = results.next();
-            userDays = entity.getList(USER_CALENDAR_KEY);
-            if(GoodDates.isEmpty()){
-                for(int i = 0; i < userDays.size(); i++){
-                    GoodDates.add(userDays.get(i));
-                }
+            try {
+                userDays = entity.getList(USER_CALENDAR_KEY);
+            } catch (DatastoreException ignored) {
+                continue;
             }
-            else{
-                for(int i = 0; i < userDays.size(); i++){
-                    if(GoodDates.contains(userDays.get(i))){
-                        temps.add(userDays.get(i));
+            if (goodDates.isEmpty()){
+                goodDates.addAll(userDays);
+            } else {
+                for (LongValue userDay : userDays) {
+                    if (goodDates.contains(userDay)) {
+                        temps.add(userDay);
                     }
                 }
-                GoodDates = temps;
+                goodDates = temps;
                 temps.clear();
             }
         }
+
+        List<Long> goodDatesList = goodDates.stream().map(Value::get).collect(Collectors.toList());
         
         Gson bson = new Gson();
         response.setContentType("application/json;");
-        response.getWriter().println(bson.toJson(GoodDates));
+        response.getWriter().println(bson.toJson(goodDatesList));
     }
 }


### PR DESCRIPTION
Sorry for moving you files Mark, this PR excludes the people that hadn't saved their calendar from participating in the matching algorithm. It basically checks if the `User` entity has the `calendar` key, and if it doesn't, it continues to the next entity.

I also mapped the set of `LongValues` into a list of `Long`s just so that the final response is more concise.