### PR TITLE
Change calendar's back button to set window location

### DIFF
--- a/src/main/webapp/js/calendar/app.js
+++ b/src/main/webapp/js/calendar/app.js
@@ -1,6 +1,15 @@
 const backBtn = document.getElementById('back-btn');
 backBtn.addEventListener('click', () => {
-  window.history.back();
+    // parse URL to get data
+    const url = new URL(window.location.href);
+    const user = url.searchParams.get('user');
+    const event = url.searchParams.get('event');
+    // Send user to calendar page
+    const params = new URLSearchParams({
+        event: event,
+        user: user
+    });
+    window.location.replace("user.html?" + params.toString())
 });
 
 const year = new Date().getFullYear();


### PR DESCRIPTION
- Set the back button to specific window location
Since the button on the user page changes the window location, I think it doesn't add the user page on history (It sends me to the create event page). So I changed it to redirect to the specific user page