### PR TITLE
Change hashset reset instruction

### DIFF
--- a/src/main/java/com/google/sps/servlets/MatchingDateAlgo.java
+++ b/src/main/java/com/google/sps/servlets/MatchingDateAlgo.java
@@ -49,7 +49,7 @@ public class MatchingDateAlgo extends HttpServlet {
                     }
                 }
                 goodDates = temps;
-                temps.clear();
+                temps = new HashSet<LongValue>();
             }
         }
 


### PR DESCRIPTION
The previous reset instruction caused the matching-date-api to not work properly (there wasn't any dates matching returned).