### PR TITLE
Add styling to calendar results

### DIFF
--- a/src/main/java/com/google/sps/servlets/MatchingDateAlgo.java
+++ b/src/main/java/com/google/sps/servlets/MatchingDateAlgo.java
@@ -49,7 +49,7 @@ public class MatchingDateAlgo extends HttpServlet {
                     }
                 }
                 goodDates = temps;
-                temps.clear();
+                temps = new HashSet<LongValue>();
             }
         }
 

--- a/src/main/webapp/css/user-style.css
+++ b/src/main/webapp/css/user-style.css
@@ -31,3 +31,15 @@ main {
 .function-button:hover {
     background-color: #5688C7;
 }
+
+ul {
+  list-style: none;
+  display: inline-block;
+  margin-right: 0.4rem;
+  text-align: left;
+  font-size: 16px;
+}
+
+ul li::before {
+  content: "📌  ";
+}

--- a/src/main/webapp/user.html
+++ b/src/main/webapp/user.html
@@ -31,16 +31,18 @@
                 </button>
             </div>
         </div>
-    </main>
-    <div class="container">
+        <br><br>
         <div class="row">
-            <div id="dates" class="col-sm-6">
-                <h3 class="text-center">Here's the dates when everyone is available:</h3>
+            <div class="col-sm-6">
+                <h3 id = "locationtext"></h3>
+                <div id = "Map"></div>
+            </div>
+            <div class="col-sm-6">
+                <div id="dates">
+                    <h3 class="text-center">Here's the dates when everyone is available:</h3>
+                </div>
             </div>
         </div>
-    </div>
-    <h4 id = "locationtext"></h4>
-    <div id = "Map"></div>
-    
+    </main>
   </body>
 </html>


### PR DESCRIPTION
- Add styling to calendar results
![image](https://user-images.githubusercontent.com/38957780/114498123-224ba480-9be9-11eb-8d34-68358a62ded9.png)
- The previous reset instruction caused the matching-date-api to not work properly (there wasn't any dates matching returned).